### PR TITLE
cyclic bit rotation implemented

### DIFF
--- a/src/milenage.erl
+++ b/src/milenage.erl
@@ -338,7 +338,6 @@ out5(OPc, K, TEMP) ->
 rot(X, 0) ->
 	X;
 rot(B, R) ->
-	Len = R div 8,
-	<<X:Len/binary, Y/binary>> = B,
-	<<Y/binary, X/binary>>.
+	<<X:R/bits, Y/bits>> = B,
+	<<Y/bits, X:R/bits>>.
 


### PR DESCRIPTION
Cyclic byte rotation changed to cyclic bit rotation.
According to 3GPP, rot(x,r) is the result of cyclically rotating the 128-bit value x by r bit positions towards the most significant bit.
